### PR TITLE
Add duplicate /vectors route to remove 307 redirects, fixes #34

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,6 +45,7 @@ def meta():
     return meta_config.get()
 
 
+@app.post("/vectors")
 @app.post("/vectors/")
 async def read_item(item: VectorInput, response: Response):
     try:


### PR DESCRIPTION
Currently, Weaviate is configured to POST to `/vectors` however the module listens on `/vectors/` causing a 307 HTTP redirects:

```
INFO:     127.0.0.1:59650 - "POST /vectors HTTP/1.1" 307 Temporary Redirect
INFO:     127.0.0.1:59651 - "POST /vectors HTTP/1.1" 307 Temporary Redirect
INFO:     127.0.0.1:59662 - "POST /vectors/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:59663 - "POST /vectors/ HTTP/1.1" 200 OK
```

This PR adds a duplicate route to remove the 307. It is non breaking as we leave the original route along (though we should deprecate it).